### PR TITLE
Add ci for python unittests no docker

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -14,4 +14,4 @@ jobs:
         run: |
           sudo apt-get install python3-venv
           ./setup.sh
-          run: ./runtests.sh
+          ./runtests.sh

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -10,5 +10,8 @@ jobs:
       - name: Checkout GitHub workspace
         uses: actions/checkout@v2
 
-      - name: Install python, activate venv, install dependencies, & run tests all in docker container
-        run: sudo docker run --rm -v $PWD:/src -w "/src" ubuntu:latest bash -c "apt update && apt -y upgrade && apt install -y python3-pip python3-venv && ./setup.sh && source ./venv/bin/activate && ./runtests.sh"
+      - name: Install python, activate venv, install dependencies, & run tests
+        run: ./setup.sh
+        run: . venv/bin/activate
+        run: ./runtests.sh
+        run: deactivate

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -11,7 +11,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install python, activate venv, install dependencies, & run tests
-        run: ./setup.sh
-        run: . venv/bin/activate
-        run: ./runtests.sh
-        run: deactivate
+        run: |
+          ./setup.sh
+          run: ./runtests.sh

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,4 +1,4 @@
-name: Run Python unittests
+name: run-python-tests
 
 on:
   push:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,5 +12,6 @@ jobs:
 
       - name: Install python, activate venv, install dependencies, & run tests
         run: |
+          sudo apt-get install python3-venv
           ./setup.sh
           run: ./runtests.sh

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,4 +1,4 @@
-name: run-python-tests
+name: tests
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ventilator Splitter Display
 ===========================
 
-![testing badge](https://github.com/tetrabiodistributed/project-tetra-display/workflows/run-python-tests/badge.svg)
+![testing badge](https://github.com/tetrabiodistributed/project-tetra-display/workflows/tests/badge.svg)
 
 A system to take pressure and flow data from sensors on a ventilator splitter, calculate descriptive parameters based on these data like PEEP or Tidal Volume, and display them for medical professionals to monitor.  This is for use against COVID-19.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Ventilator Splitter Display
 ===========================
 
+https://github.com/tetrabiodistributed/project-tetra-display/workflow/run-python-tests/badge.svg
+
 A system to take pressure and flow data from sensors on a ventilator splitter, calculate descriptive parameters based on these data like PEEP or Tidal Volume, and display them for medical professionals to monitor.  This is for use against COVID-19.
 
 To set it up for tests, run `./setup.sh` to build the virtual environment and then `source ./venv/bin/activate` to activate it.  To do the tests, run `./runtests.sh`.  This will first show the results of unit tests and then behaviour tests.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ventilator Splitter Display
 ===========================
 
-https://github.com/tetrabiodistributed/project-tetra-display/workflow/run-python-tests/badge.svg
+https://github.com/tetrabiodistributed/project-tetra-display/workflows/run-python-tests/badge.svg
 
 A system to take pressure and flow data from sensors on a ventilator splitter, calculate descriptive parameters based on these data like PEEP or Tidal Volume, and display them for medical professionals to monitor.  This is for use against COVID-19.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ventilator Splitter Display
 ===========================
 
-https://github.com/tetrabiodistributed/project-tetra-display/workflows/run-python-tests/badge.svg
+![testing badge](https://github.com/tetrabiodistributed/project-tetra-display/workflows/run-python-tests/badge.svg)
 
 A system to take pressure and flow data from sensors on a ventilator splitter, calculate descriptive parameters based on these data like PEEP or Tidal Volume, and display them for medical professionals to monitor.  This is for use against COVID-19.
 

--- a/runtests.sh
+++ b/runtests.sh
@@ -3,6 +3,16 @@
 . venv/bin/activate
 echo "Behaviour Tests:"
 behave
+behave_exit_code=$?
 echo $'\nUnit Tests:'
 python3 -m unittest
+unittest_exit_code=$?
 deactivate
+
+if [ $behave_exit_code -ne 0 ]; then
+    echo "behave tests failed!"
+fi
+if [ $unittest_exit_code -ne 0 ]; then
+    echo "unittests tests failed!"
+fi
+exit $(($behave_exit_code + $unittest_exit_code))

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
+. venv/bin/activate
 echo "Behaviour Tests:"
 behave
 echo $'\nUnit Tests:'
 python3 -m unittest
+deactivate

--- a/setup.sh
+++ b/setup.sh
@@ -19,6 +19,3 @@ deactivate
 if ! command -v docker &> /dev/null; then
     printf "\n${HIGHLIGHT}Please install Docker${NO_COLOR}"
 fi
-
-echo $'\nRun this to start the virtual environment'
-printf "${HIGHLIGHT}. venv/bin/activate${NO_COLOR}\n"


### PR DESCRIPTION
changed the unit test cicd to not use docker because I looked into doing docker-in-docker and docker compose, and it seems like a giant pita that we can just skip by running everything directly on whatever machine github gives us.  It's not like we're concerned about the external machine state anyway since the tests run in a venv.