### PR TITLE
Feature/flow sensor testing script

### DIFF
--- a/Scripts/poll_sfm3300d.py
+++ b/Scripts/poll_sfm3300d.py
@@ -1,0 +1,21 @@
+import time
+
+from tca9548a import I2CMux
+from sfm3300d import FlowSensor
+import constants
+
+
+if "__main__" == __name__:
+    mux = I2CMux(constants.FLOW_SENSOR_MUX_ADDRESS)
+    mux.select_channel(1)
+    sensor = FlowSensor(dump_communication=False)
+
+    running = True
+    while running:
+        try:
+            print(f"{time.time()}\t{sensor.flow()}")
+            time.sleep(1.0)
+        except KeyboardInterrupt:
+            running = False
+            sensor.close()
+            mux.close()


### PR DESCRIPTION
If you plug the Sensirion sensor into port 1, then you can run this bit of code to see some data out of it

```bash
python3 poll_sfm3300d
# 1598813840.930911	0.0
# 1598813841.9330535	0.0
# 1598813842.9361587	-0.03333333333333333
# 1598813843.9392972	0.0
# 1598813844.9423778	0.03333333333333333
# 1598813845.9454865	-0.13333333333333333
# 1598813846.9486084	40.3
# 1598813847.951721	44.166666666666664
```

An issue to fix is that you have to first copy `poll_sfm3300d.py` from `Scripts/` to root, otherwise when you run the script, it won't see any of its dependencies.